### PR TITLE
fix: we need '?' at end of url due to VPM's bug

### DIFF
--- a/vpm.json
+++ b/vpm.json
@@ -16,7 +16,7 @@
           "licensesUrl": "https://github.com/lilxyzw/lilToon/blob/master/Assets/lilToon/LICENSE",
           "license": "MIT",
           "keywords": ["Toon", "Shader", "Material"],
-          "url" : "https://github.com/lilxyzw/lilToon/releases/download/1.3.7/jp.lilxyzw.liltoon-1.3.7.zip",
+          "url" : "https://github.com/lilxyzw/lilToon/releases/download/1.3.7/jp.lilxyzw.liltoon-1.3.7.zip?",
           "legacyFolders" : {
             "Assets\\lilToon" : "05d1d116436047941ad97d1b9064ee05"
           }


### PR DESCRIPTION
VPMのバグにより、`?`が末尾にないとエラーを吐きます。これの修正です。

```
Couldn't download package from url https://github.com/lilxyzw/lilToon/releases/download/1.3.7/jp.lilxyzw.liltoon-1.3.7.zip&time=133216905109760660: Not Found
```