### PR TITLE
add id field

### DIFF
--- a/vpm.json
+++ b/vpm.json
@@ -1,5 +1,6 @@
 {
   "name": "lilxyzw",
+  "id": "io.github.lilxyzw.vpm",
   "author": "lilxyzw",
   "url": "https://lilxyzw.github.io/vpm-repos/vpm.json",
   "packages": {


### PR DESCRIPTION
- vrchat-community/creator-companion#214
- vrchat-community/template-package-listing#4

Becuase `lilxyzw.jp` is not a valid domain (according to whois), I use `lilxyzw.github.io` instead.