### PR TITLE
fix: Update download URL of lilAnythingReplacer 1.0.0 (404 NotFound Error)

### DIFF
--- a/vpm.json
+++ b/vpm.json
@@ -1398,7 +1398,7 @@
           "displayName": "lilAnythingReplacer",
           "description": "Replace references at build time.",
           "unity": "2022.3",
-          "url": "https://github.com/lilxyzw/lilAnythingReplacer/releases/download/1.0.0/jp.lilxyzw.anythingreplacer-1.0.0.zip?",
+          "url": "https://github.com/lilxyzw/lilAnythingReplacer/releases/download/1.0.0/jp.lilxyzw.anythingreplacer.zip?",
           "repo": "https://lilxyzw.github.io/vpm-repos/vpm.json",
           "vpmDependencies": {
             "nadena.dev.ndmf": "^1.5.0"


### PR DESCRIPTION
https://github.com/lilxyzw/lilAnythingReplacer/releases/tag/1.0.0

上記URLより取得できるURLには`-1.0.0`が含まれておらず、404エラーとなってしまう事象を解消します